### PR TITLE
Changes Revision and Config parsing order

### DIFF
--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -919,6 +919,20 @@ func (c applicationsClient) UpdateApplication(input *UpdateApplicationInput) err
 		return fmt.Errorf("no status returned for application: %s", input.AppName)
 	}
 
+	// Use the revision and channel info to create the
+	// corresponding SetCharm info.
+	if input.Revision != nil || input.Channel != "" {
+		setCharmConfig, err := c.computeSetCharmConfig(input, applicationAPIClient, charmsAPIClient, resourcesAPIClient)
+		if err != nil {
+			return err
+		}
+
+		err = applicationAPIClient.SetCharm(model.GenerationMaster, *setCharmConfig)
+		if err != nil {
+			return err
+		}
+	}
+
 	// process configuration
 	var auxConfig map[string]string
 	if input.Config != nil {
@@ -1017,20 +1031,6 @@ func (c applicationsClient) UpdateApplication(input *UpdateApplicationInput) err
 					return err
 				}
 			}
-		}
-	}
-
-	// Use the revision and channel info to create the
-	// corresponding SetCharm info.
-	if input.Revision != nil || input.Channel != "" {
-		setCharmConfig, err := c.computeSetCharmConfig(input, applicationAPIClient, charmsAPIClient, resourcesAPIClient)
-		if err != nil {
-			return err
-		}
-
-		err = applicationAPIClient.SetCharm(model.GenerationMaster, *setCharmConfig)
-		if err != nil {
-			return err
 		}
 	}
 

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -147,6 +147,7 @@ func TestAcc_ResourceApplication_UpdatesRevisionConfig(t *testing.T) {
 	}
 	modelName := acctest.RandomWithPrefix("tf-test-application")
 	appName := "github-runner"
+	configParamName := "runner-storage"
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
@@ -161,9 +162,10 @@ func TestAcc_ResourceApplication_UpdatesRevisionConfig(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccResourceApplicationWithRevisionAndConfig(modelName, appName, 95, ""),
+				Config: testAccResourceApplicationWithRevisionAndConfig(modelName, appName, 95, configParamName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_application."+appName, "charm.0.revision", "95"),
+					resource.TestCheckResourceAttr("juju_application."+appName, "config."+configParamName, configParamName+"-value"),
 				),
 			},
 		},


### PR DESCRIPTION
This PR changes the Revision and Config parsing order and provides needed checks in the unit test.

QA Steps
```
TF_ACC=1 TEST_CLOUD=lxd go test -v ./internal/provider/ -parallel=1 -run TestAcc_ResourceApplication_UpdatesRevisionConfig
```